### PR TITLE
Configure SSH key to connect to installer host

### DIFF
--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -68,7 +68,7 @@ resource "azurerm_linux_virtual_machine" "aap_infrastructure_vm" {
     username = var.infrastructure_admin_username
     public_key = file(var.infrastructure_admin_ssh_public_key_filepath)
   }
-  
+
   disable_password_authentication = true
   admin_username = var.infrastructure_admin_username
 
@@ -79,4 +79,16 @@ resource "azurerm_linux_virtual_machine" "aap_infrastructure_vm" {
     },
     var.persistent_tags
   )
+
+  # Copy SSH private key file to the installer host to connect to other servers
+  provisioner "file" {
+    connection {
+      type = "ssh"
+      user = "azureuser"
+      host        = azurerm_public_ip.aap_infrastructure_public_ip.ip_address
+      private_key = file(var.infrastructure_admin_ssh_private_key_filepath)
+    }
+    source = "${var.infrastructure_admin_ssh_private_key_filepath}"
+    destination = "/home/azureuser/.ssh/infrastructure_ssh_private_key.pem"
+    }
 }

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -81,8 +81,12 @@ resource "azurerm_linux_virtual_machine" "aap_infrastructure_vm" {
   )
   }
 
+# Copy SSH private key file to controller vm's to connect to other servers
 resource "terraform_data" "aap_infrastructure_vm" {
     count = var.app_tag == "controller" ? 1: 0
+    triggers_replace = [
+      azurerm_linux_virtual_machine.aap_infrastructure_vm.id
+    ]
     provisioner "file" {
       connection {
         type = "ssh"

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -79,16 +79,18 @@ resource "azurerm_linux_virtual_machine" "aap_infrastructure_vm" {
     },
     var.persistent_tags
   )
+  }
 
-  # Copy SSH private key file to the installer host to connect to other servers
-  provisioner "file" {
-    connection {
-      type = "ssh"
-      user = "azureuser"
-      host        = azurerm_public_ip.aap_infrastructure_public_ip.ip_address
-      private_key = file(var.infrastructure_admin_ssh_private_key_filepath)
-    }
-    source = "${var.infrastructure_admin_ssh_private_key_filepath}"
-    destination = "/home/azureuser/.ssh/infrastructure_ssh_private_key.pem"
-    }
+resource "terraform_data" "aap_infrastructure_vm" {
+    count = var.app_tag == "controller" ? 1: 0
+    provisioner "file" {
+      connection {
+        type = "ssh"
+        user = "azureuser"
+        host        = azurerm_public_ip.aap_infrastructure_public_ip.ip_address
+        private_key = file(var.infrastructure_admin_ssh_private_key_filepath)
+      }
+      source = "${var.infrastructure_admin_ssh_private_key_filepath}"
+      destination = "/home/azureuser/.ssh/infrastructure_ssh_private_key.pem"
+      }
 }

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -123,3 +123,9 @@ variable "infrastructure_admin_ssh_public_key_filepath" {
   type = string
   default = "~/.ssh/id_rsa.pub"
 }
+
+variable "infrastructure_admin_ssh_private_key_filepath" {
+  description = "Private ssh key file path."
+  type = string
+  default = "~/.ssh/id_rsa"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,15 @@ variable "infrastructure_hub_count" {
   type = number
   default = 1
 }
+
+variable "infrastructure_admin_ssh_public_key_filepath" {
+  description = "Public ssh key file path."
+  type = string
+  default = "~/.ssh/id_rsa.pub"
+}
+
+variable "infrastructure_admin_ssh_private_key_filepath" {
+  description = "Private ssh key file path."
+  type = string
+  default = "~/.ssh/id_rsa"
+}


### PR DESCRIPTION
This PR is for configuring SSH key to connect to installer host and other servers.

Jira: https://issues.redhat.com/browse/AAP-18976

Steps to test:
1. Test by passing SSH public key and its corresponding private key as an extra var in user input, 
2. `infrastructure_controller_count` var can be used to create a number of controller instances and check if user is able to ssh from 1 controller vm to another controller vm
3. Example command:
```

terraform init && terraform validate && terraform apply -var="infrastructure_admin_ssh_public_key_filepath=/home/shkhedka/.ssh/sktestaap18976.pub" -var="infrastructure_admin_ssh_private_key_filepath=/home/shkhedka/.ssh/sktestaap18976" -var="infrastructure_controller_count=2"

```

Expected output:
1. User is able to SSH to controller vm's
2. SSH private key is copied to controller vm
2. User is able to SSH from 1 controller vm to another controller vm
3. User provided Private SSH key should be copied only to controller vm's
